### PR TITLE
Removed unused condition for hidePadding prop of nav item

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -82,7 +82,7 @@ export const App: React.FC = () => {
             title: page.title,
             itemID: page.route || itemKey,
             items: subItems.length > 0 ? subItems : undefined,
-            hidePadding: !(Object.keys(page).includes('route') && isSubItem),
+            hidePadding: !isSubItem,
             onClick: page.route
                 ? (): void => {
                       if (page.route) navigate(page.route); // this extra if shouldn't be necessary, but TS doesn't understand that it can't be undefined because of the ternary operator.


### PR DESCRIPTION
Fixes #105 BLUI-3715

Changes - 
Removed unused condition to check the availability of route in hidePadding prop of nav item

Screenshots:
<img width="1792" alt="Screenshot 2023-01-06 at 3 02 31 PM" src="https://user-images.githubusercontent.com/120575281/210972943-3e42ec1f-3291-408a-bef0-0c26c62372df.png">

To test-
- yarn start
- Open any left side navigation drawer item which has children
- The children should have left padding