### PR TITLE
no merge update firebase pr deploy to ignore dependabot

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -5,6 +5,7 @@ name: Deploy to Firebase Hosting on PR
 'on': pull_request
 jobs:
   build_and_preview:
+    if: '${{ github.actor != 'dependabot[bot]' }}'
     if: '${{ github.event.pull_request.head.repo.full_name == github.repository }}'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
This change should skip the PR Firebase deploy and stop failing.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- update firebase action if GitHub actor dependabot (skip)
- 
- 

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots / Screen Recording (if applicable)
-


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- 

<!-- Useful for draft pull requests -->
#### Any specific feedback you are looking for?
-


